### PR TITLE
Added namespace to replace for tf 1.15

### DIFF
--- a/ssd/build_engine.py
+++ b/ssd/build_engine.py
@@ -159,6 +159,7 @@ def add_plugin(graph, model, spec):
         "Postprocessor": NMS,
         "Preprocessor": Input,
         "ToFloat": Input,
+        "Cast": Input, #added for models trained with tf 1.15
         "image_tensor": Input,
         "MultipleGridAnchorGenerator/Concatenate": concat_priorbox,  # for 'ssd_mobilenet_v1_coco'
         "Concatenate": concat_priorbox,  # for other models


### PR DESCRIPTION
Since the "ToFloat"-operation was renamed in tf 1.15 this should fix the "Cast"-error, caused by training with tf 1.15.