### PR TITLE
Fix "TypeError: 'int' object is not subscriptable" with tiny-3l

### DIFF
--- a/yolo/plugins.py
+++ b/yolo/plugins.py
@@ -41,7 +41,7 @@ def get_yolo_whs(model_name, w, h):
             return [[w // 32, h // 32], [w // 16, h // 16], [w // 8, h // 8]]
     elif 'yolov4' in model_name:
         if 'tiny-3l' in model_name:
-            return [(h // 32) * (w // 32), (h // 16) * (w // 16), (h // 8) * (w // 8)]
+            return [[w // 32, h // 32], [w // 16, h // 16], [w // 8, h // 8]]
         elif 'tiny' in model_name:
             return [[w // 32, h // 32], [w // 16, h // 16]]
         else:


### PR DESCRIPTION
When I used the `yolov4-tiny-3l` model then running `trt_yolo.py` I got the error `TypeError: 'int' object is not subscriptable`.

