### PR TITLE
Fix yolo layer plugin loading

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -34,4 +34,4 @@ libyolo_layer.so: yolo_layer.o
 	$(CC) -shared -o $@ $< $(LIBS)
 
 yolo_layer.o: yolo_layer.cu yolo_layer.h
-	$(NVCC) -ccbin $(CC) $(INCS) $(NVCCFLAGS) -Xcompiler -fPIC -c -o $@ $<
+	$(NVCC) -ccbin $(CC) $(INCS) $(NVCCFLAGS) -lnvinfer -lcudart -Xcompiler -fPIC -c -o $@ $<

--- a/plugins/yolo_layer.cu
+++ b/plugins/yolo_layer.cu
@@ -427,5 +427,4 @@ namespace nvinfer1
 
     PluginFieldCollection YoloPluginCreator::mFC{};
     std::vector<PluginField> YoloPluginCreator::mPluginAttributes;
-    REGISTER_TENSORRT_PLUGIN(YoloPluginCreator);
 } // namespace nvinfer1

--- a/plugins/yolo_layer.h
+++ b/plugins/yolo_layer.h
@@ -137,7 +137,7 @@ namespace nvinfer1
 
         private:
             static PluginFieldCollection mFC;
-            static std::vector<nvinfer1::PluginField> mPluginAttributes;
+            static std::vector<PluginField> mPluginAttributes;
             std::string mNamespace;
     };
 

--- a/plugins/yolo_layer.h
+++ b/plugins/yolo_layer.h
@@ -140,6 +140,8 @@ namespace nvinfer1
             static std::vector<nvinfer1::PluginField> mPluginAttributes;
             std::string mNamespace;
     };
+
+    REGISTER_TENSORRT_PLUGIN(YoloPluginCreator);
 };
 
 #endif


### PR DESCRIPTION
For more information on why this change is necessary see https://github.com/wang-xinyu/tensorrtx/issues/107

Please double check the change in the Makefile. I use CMake in my project and the necessary change is:

`target_link_libraries(layerplugin nvinfer cudart)`

So I hope the appended diff is the equivalent Makefile change.

After this change you can run the tensorrt engine with trtexec using the following command (change paths ofc):

`./trtexec --loadEngine=/yolov4-triton-tensorrt/build/yolov4.engine --plugins=/yolov4-triton-tensorrt/build/liblayerplugin.so`