### PR TITLE
Allow arbitrary number of anchors (masks) in YOLO layer

### DIFF
--- a/utils/yolo_with_plugins.py
+++ b/utils/yolo_with_plugins.py
@@ -174,6 +174,10 @@ class HostDeviceMem(object):
     def __repr__(self):
         return self.__str__()
 
+    def __del__(self):
+        del self.device
+        del self.host        
+
 
 def get_input_shape(engine):
     """Get input shape of the TensorRT YOLO engine."""

--- a/yolo/download_yolo.sh
+++ b/yolo/download_yolo.sh
@@ -30,6 +30,10 @@ wget https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v4_pre/y
 wget https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov4x-mish.cfg -q --show-progress --no-clobber
 wget https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v4_pre/yolov4x-mish.weights -q --show-progress --no-clobber
 
+# yolov4-p5
+wget https://raw.githubusercontent.com/AlexeyAB/darknet/master/cfg/yolov4-p5.cfg -q --show-progress --no-clobber
+wget https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v4_pre/yolov4-p5.weights -q --show-progress --no-clobber
+
 echo
 echo "Creating yolov3-tiny-288.cfg and yolov3-tiny-288.weights"
 cat yolov3-tiny.cfg | sed -e '8s/width=416/width=288/' | sed -e '9s/height=416/height=288/' > yolov3-tiny-288.cfg
@@ -93,6 +97,12 @@ echo "Creating yolov4x-mish-640.cfg and yolov4x-mish-640.weights"
 cat yolov4x-mish.cfg | sed -e '6s/batch=64/batch=1/' > yolov4x-mish-640.cfg
 ln -sf yolov4x-mish.weights yolov4x-mish-640.weights
 
+echo "Creating yolov4-p5-448.cfg and yolov4-p5-448.weights"
+cat yolov4-p5.cfg | sed -e '6s/batch=64/batch=1/' | sed -e '8s/width=896/width=448/' | sed -e '9s/height=896/height=448/' > yolov4-p5-448.cfg
+ln -sf yolov4-p5.weights yolov4-p5-448.weights
+echo "Creating yolov4-p5-896.cfg and yolov4-p5-896.weights"
+cat yolov4-p5.cfg | sed -e '6s/batch=64/batch=1/' > yolov4-p5-896.cfg
+ln -sf yolov4-p5.weights yolov4-p5-896.weights
+
 echo
 echo "Done."
-

--- a/yolo/onnx_to_tensorrt.py
+++ b/yolo/onnx_to_tensorrt.py
@@ -186,7 +186,7 @@ def main():
     parser.add_argument(
         '-m', '--model', type=str, required=True,
         help=('[yolov3-tiny|yolov3|yolov3-spp|yolov4-tiny|yolov4|'
-              'yolov4-csp|yolov4x-mish]-[{dimension}], where '
+              'yolov4-csp|yolov4x-mish|yolov4-p5]-[{dimension}], where '
               '{dimension} could be either a single number (e.g. '
               '288, 416, 608) or 2 numbers, WxH (e.g. 416x256)'))
     parser.add_argument(

--- a/yolo/yolo_to_onnx.py
+++ b/yolo/yolo_to_onnx.py
@@ -52,6 +52,7 @@
 import os
 import sys
 import argparse
+import re
 from collections import OrderedDict
 
 import numpy as np
@@ -136,6 +137,24 @@ def get_h_and_w(layer_configs):
     """Find input height and width of the yolo model from layer configs."""
     net_config = layer_configs['000_net']
     return net_config['height'], net_config['width']
+
+
+def get_anchor_num(cfg_file_path):
+    """Find number of anchors (masks) of the yolo model."""
+
+    # Read configuration file
+    with open(cfg_file_path, 'r') as f:
+        cfg = f.read()
+
+    # Find number of anchors from `mask` field, e.g. mask=0,1,2,3
+    pattern = r'mask\s?=(.+)'
+    matches = re.findall(pattern, cfg)
+    num_anchors = [len(match.strip().split(',')) for match in matches]
+
+    assert len(num_anchors) > 0, 'Found no `mask` fields in config'
+    assert len(set(num_anchors)) == 1, 'Found different num anchors'
+
+    return num_anchors[0]
 
 
 class DarkNetParser(object):
@@ -974,7 +993,7 @@ def main():
     output_tensor_names = get_output_convs(layer_configs)
     # e.g. ['036_convolutional', '044_convolutional', '052_convolutional']
 
-    c = (category_num + 5) * 3
+    c = (category_num + 5) * get_anchor_num(cfg_file_path)
     h, w = get_h_and_w(layer_configs)
     if len(output_tensor_names) == 2:
         output_tensor_shapes = [

--- a/yolo/yolo_to_onnx.py
+++ b/yolo/yolo_to_onnx.py
@@ -72,7 +72,7 @@ def parse_args():
     parser.add_argument(
         '-m', '--model', type=str, required=True,
         help=('[yolov3-tiny|yolov3|yolov3-spp|yolov4-tiny|yolov4|'
-              'yolov4-csp|yolov4x-mish]-[{dimension}], where '
+              'yolov4-csp|yolov4x-mish|yolov4-p5]-[{dimension}], where '
               '{dimension} could be either a single number (e.g. '
               '288, 416, 608) or 2 numbers, WxH (e.g. 416x256)'))
     args = parser.parse_args()


### PR DESCRIPTION
This allows for models like YOLOv4-P5 with 4 anchors in each YOLO layer to be converted to ONNX and then to TensorRT, by simply parsing the configuration file. Tested for YOLOv4-P5 with dimensions 896 (original config dimensions) and 448.