### PR TITLE
solve --no-use-shipped-boost

### DIFF
--- a/yolo/install_pycuda.sh
+++ b/yolo/install_pycuda.sh
@@ -34,6 +34,8 @@ echo "** cpu cores available: " $CPU_CORES
 tar xzvf pycuda-2019.1.2.tar.gz
 cd pycuda-2019.1.2
 python3 ./configure.py --python-exe=/usr/bin/python3 --cuda-root=/usr/local/cuda --cudadrv-lib-dir=/usr/lib/${arch}-linux-gnu --boost-inc-dir=/usr/include --boost-lib-dir=/usr/lib/${arch}-linux-gnu --boost-python-libname=${boost_pyname} --boost-thread-libname=boost_thread --no-use-shipped-boost
+# if you get --no-use-shipped-boost run follow remove command
+# rm siteconf.py
 make -j$CPU_CORES
 python3 setup.py build
 sudo python3 setup.py install


### PR DESCRIPTION
if not add this rm command to bash script, we need to remove the siteconf.py after running ./configure.py